### PR TITLE
Added absolute paths

### DIFF
--- a/post_proc/Android.mk
+++ b/post_proc/Android.mk
@@ -98,8 +98,8 @@ ifneq ($(BOARD_OPENSOURCE_DIR), )
    LOCAL_C_INCLUDES += $(BOARD_OPENSOURCE_DIR)/audio-hal/primary-hal/hal \
                        $(BOARD_OPENSOURCE_DIR)/audio-hal/primary-hal/hal/audio_extn/
 else
-   LOCAL_C_INCLUDES += $(TARGET_HALS_PATH)/audio/hal \
-                       $(TARGET_HALS_PATH)/audio/hal/audio_extn/
+   LOCAL_C_INCLUDES += hardware/qcom-caf/bengal/audio/hal \
+                       hardware/qcom-caf/bengal/audio/hal/audio_extn/
 endif # BOARD_OPENSOURCE_DIR
 
 ifeq ($(strip $(AUDIO_FEATURE_ENABLED_DLKM)),true)


### PR DESCRIPTION
During compilation, the variable TARGET_HALS_PATH is empty, and so the libraries take up the absolute path starting with root path (/). So, added the correct paths to the libraries.